### PR TITLE
optimize case abount delegate lockPeriod and MongoEventQuery

### DIFF
--- a/testcase/src/test/java/stest/tron/wallet/dailybuild/operationupdate/MutiSignClearContractAbiTest.java
+++ b/testcase/src/test/java/stest/tron/wallet/dailybuild/operationupdate/MutiSignClearContractAbiTest.java
@@ -134,7 +134,7 @@ public class MutiSignClearContractAbiTest {
     logger.info(accountPermissionJson);
     PublicMethedForMutiSign.accountPermissionUpdate(accountPermissionJson, ownerAddress, ownerKey,
         blockingStubFull, ownerKeyString);
-
+    PublicMethed.waitProduceNextBlock(blockingStubFull);
     Long maxFeeLimit = 1000000000L;
     String filePath = "./src/test/resources/soliditycode/TriggerConstant004.sol";
     String contractName = "testConstantContract";
@@ -148,7 +148,7 @@ public class MutiSignClearContractAbiTest {
     PublicMethed.waitProduceNextBlock(blockingStubFull);
 //    PublicMethed.waitProduceNextBlock(blockingStubFull);
     SmartContract smartContract = PublicMethed.getContract(contractAddress, blockingStubFull);
-    Assert.assertTrue(smartContract.getAbi().toString() != null);
+    Assert.assertNotEquals(smartContract.getAbi().toString(), "");
     Assert.assertTrue(PublicMethedForMutiSign
         .clearContractAbi(contractAddress, ownerAddress, ownerKey,
             blockingStubFull, 2, permissionKeyString));


### PR DESCRIPTION
1.optimize case in FreezeBalanceV2Test006
2.add check in MongoEventQuery003 for redundancy = true case 
3.fix case MutiSignClearContractAbiTest

**What does this PR do?**

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

