### PR TITLE
fix(config): replace external.ip=null with empty string

### DIFF
--- a/testcase/src/test/resources/config-localtest.conf
+++ b/testcase/src/test/resources/config-localtest.conf
@@ -59,7 +59,7 @@ node.discovery = {
   enable = true
   persist = true
   bind.ip = ""
-  external.ip = null
+  external.ip = ""
 }
 
 node.backup {

--- a/testcase/src/test/resources/config-test-dbbackup.conf
+++ b/testcase/src/test/resources/config-test-dbbackup.conf
@@ -62,7 +62,7 @@ node.discovery = {
   enable = true
   persist = true
   bind.ip = ""
-  external.ip = null
+  external.ip = ""
 }
 
 node.backup {

--- a/testcase/src/test/resources/config-test-index.conf
+++ b/testcase/src/test/resources/config-test-index.conf
@@ -55,7 +55,7 @@ node.discovery = {
   enable = true
   persist = true
   bind.ip = ""
-  external.ip = null
+  external.ip = ""
 }
 
 node {


### PR DESCRIPTION
## What

Replace `external.ip = null` with `external.ip = ""` in 3 test config files.

## Why

HOCON `null` values cannot be bound by `ConfigBeanFactory` to `String` fields.
Using empty string instead has the same runtime effect — it triggers the automatic
IP detection fallback in java-tron. This avoids `ConfigException$Null` when
java-tron adopts `ConfigBeanFactory` for config binding.

## Changed files

- `config-localtest.conf`
- `config-test-dbbackup.conf`
- `config-test-index.conf`

Related: tronprotocol/java-tron#6615